### PR TITLE
Option nsfm=true shouldn't exclude sfm sessions

### DIFF
--- a/inclsrv/queries.go
+++ b/inclsrv/queries.go
@@ -106,7 +106,7 @@ func filterSessionList(sessions []db.SessionInfo, opts db.QueryOptions) []db.Ses
 	for _, s := range sessions {
 		if
 			(opts.Title == "" || strings.Contains(s.Title, opts.Title)) &&
-			(opts.Nsfm == s.Nsfm) &&
+			(opts.Nsfm || !s.Nsfm) &&
 			(opts.Protocol == "" || strings.Contains(s.Protocol, opts.Protocol)) {
 
 			filtered = append(filtered, s)


### PR DESCRIPTION
If NFSM is ticked in the server browser, client sends the following request to the list server: `GET /drawpile/listing/sessions/?nsfm=true`, it returns the NSFM sessions **ONLY**

This change makes it so NSFM option includes the SFM sessions when set to true. When set to false, it will only show SFM sessions.